### PR TITLE
feat(logs): JSON console logs via logstash encoder; test(web): add Mo…

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>net.logstash.logback</groupId>
+      <artifactId>logstash-logback-encoder</artifactId>
+      <version>7.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>2.6.0</version>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<configuration>
+  <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+      <providers>
+        <timestamp>
+          <timeZone>UTC</timeZone>
+        </timestamp>
+        <logLevel/>
+        <loggerName/>
+        <threadName/>
+        <message/>
+        <mdc>
+          <includeMdcKeyName>correlationId</includeMdcKeyName>
+        </mdc>
+        <context/>
+        <stackTrace>
+          <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+            <maxDepthPerThrowable>50</maxDepthPerThrowable>
+            <rootCauseFirst>true</rootCauseFirst>
+          </throwableConverter>
+        </stackTrace>
+      </providers>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="JSON_CONSOLE"/>
+  </root>
+</configuration>
+

--- a/backend/src/test/java/com/todo/eod/web/WebhookControllerTest.java
+++ b/backend/src/test/java/com/todo/eod/web/WebhookControllerTest.java
@@ -1,0 +1,44 @@
+package com.todo.eod.web;
+
+import com.todo.eod.app.WebhookIngestService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WebhookController.class)
+class WebhookControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    WebhookIngestService ingest;
+
+    @Test
+    void postGithubWebhook_returns200_whenAccepted() throws Exception {
+        when(ingest.ingest(anyString(), anyString(), anyString(), any())).thenReturn(WebhookIngestService.IngestResult.ok());
+
+        String body = "{" +
+                "\"eventId\":\"gh-evt-123\"," +
+                "\"type\":\"PR_MERGED\"," +
+                "\"repo\":\"org/app\"," +
+                "\"branch\":\"main\"," +
+                "\"pr\":42," +
+                "\"taskKey\":\"TSK-123\"" +
+                "}";
+
+        mvc.perform(post("/webhooks/github")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+    }
+}
+


### PR DESCRIPTION
…ckMvc test for /webhooks/github (happy path)

# Title & Branch

<!-- Title format: type(scope): short summary  -->
<!-- Branch format: type/short-kebab-summary (e.g., feat/add-agents-md) -->

# Summary

<!-- Briefly describe the purpose and scope of this PR. -->

# Context & Links

<!-- Link related issues and docs. Use keywords: Closes #123, Relates to #456. -->

# Changes

<!-- High-level list of changes. Keep it concise. -->
- 

# How to Test

<!-- Exact steps/commands to verify. Include sample requests if relevant. -->
```bash
# Start dependencies (dev)
docker compose up -d

# Build & run backend
cd backend
./mvnw verify
./mvnw spring-boot:run
```

Optional quick checks:
- Swagger UI: http://localhost:8080/swagger-ui/index.html
- Example requests: see `api.http`

# Screenshots / Logs (optional)

<!-- Paste images or logs that demonstrate behavior. -->

---

## Objetivo
Sincronizar documentação e contratos.

## Checklist (Docs)
- [ ] OpenAPI regenerado (`mvn ... springdoc ... generate`)
- [ ] Lint OK (`redocly lint`)
- [ ] README com versões atualizadas
- [ ] ERD/schema atualizado (placeholder)
- [ ] Exemplos HTTP verificados (se aplicável)

## Checklist
- [ ] Commit messages follow Conventional Commits
- [ ] PR title follows `type(scope): summary`
- [ ] Branch name follows `type/short-kebab-summary`
- [ ] CHANGELOG updated (Unreleased) with user-facing changes
- [ ] Clear summary and context provided
- [ ] Linked issues (e.g., Closes #123)
- [ ] Tests added/updated and pass `./mvnw verify`
- [ ] Docs updated (README/AGENTS.md)
- [ ] OpenAPI updated and versioned (docs/openapi/openapi-${project.version}.json)
- [ ] DB migrations added if needed (Flyway `db/migration`)
- [ ] No secrets committed; logs avoid sensitive data
- [ ] Backward compatibility considered (breaking changes documented)

## Type
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] test
- [ ] refactor
- [ ] chore
